### PR TITLE
Added a script to adapt existing patterns

### DIFF
--- a/scripts/e2pat_shift.py
+++ b/scripts/e2pat_shift.py
@@ -5,7 +5,7 @@
 # This means, though, that all factory samples have to move to slots 501+.
 #
 # I wanted to keep my existing patterns, this kept me from installing HACKTRIBE - 
-# but now that I've done it 
+# but now that I've done it, I did not want to correct all existing patterns by hand
 
 import argparse
 


### PR DESCRIPTION
Having to move all factory samples to OSC slots 501+ means having to shift all OSC numbers in all patterns to the new locations (apart from the factory waveforms 1-18 which remain the same). Simple script to shift all OSC numbers to the new locations. 

First pull request here, forgive me if necessary info is missing. 